### PR TITLE
feat(module): mac addresses now ignore the prefix changes

### DIFF
--- a/xen_master.tf
+++ b/xen_master.tf
@@ -15,6 +15,11 @@ locals {
 
 resource "macaddress" "mac_master_primary" {
   prefix = [0, 22, 62]
+
+  lifecycle {
+    ignore_changes = [prefix]
+  }
+
 }
 
 resource "xenorchestra_cloud_config" "master" {

--- a/xen_nodes.tf
+++ b/xen_nodes.tf
@@ -11,6 +11,11 @@ resource "random_integer" "node" {
 resource "macaddress" "mac_nodes" {
   count  = var.node_count
   prefix = [0, 22, 62]
+
+  lifecycle {
+    ignore_changes = [prefix]
+  }
+
 }
 
 resource "xenorchestra_cloud_config" "node" {

--- a/xen_secondaries.tf
+++ b/xen_secondaries.tf
@@ -52,6 +52,11 @@ EOF
 resource "macaddress" "mac_master_secondaries" {
   count  = var.master_count - 1
   prefix = [0, 22, 62]
+
+  lifecycle {
+    ignore_changes = [prefix]
+  }
+
 }
 
 


### PR DESCRIPTION
This is to help when importing mac addresses from a previous version of the module.