### PR TITLE
feat(module): Remove empty terraform providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,8 @@ No modules.
 | <a name="input_public_ssh_key"></a> [public\_ssh\_key](#input\_public\_ssh\_key) | Public SSH key for accessing the nodes | `string` | n/a | yes |
 | <a name="input_start_delay"></a> [start\_delay](#input\_start\_delay) | The amount of time the cluster virtual machines will wait on XCP-NG host startup | `number` | `0` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A list of key+value pairs to apply to the deployment | `list(string)` | `[]` | no |
-| <a name="input_xoa_api_url"></a> [xoa\_api\_url](#input\_xoa\_api\_url) | URL for Xen Orchestra API (can be set via XOA\_API\_URL environment variable) | `string` | n/a | yes |
-| <a name="input_xoa_ignore_ssl"></a> [xoa\_ignore\_ssl](#input\_xoa\_ignore\_ssl) | Ignore SSL verification for Xen Orchestra API (can be set via XOA\_IGNORE\_SSL environment variable) | `bool` | `null` | no |
 | <a name="input_xoa_network_name"></a> [xoa\_network\_name](#input\_xoa\_network\_name) | Default network for virtual machines as seen in Xen Orchestra | `string` | `null` | no |
-| <a name="input_xoa_password"></a> [xoa\_password](#input\_xoa\_password) | Password for Xen Orchestra API (can be set via XOA\_PASSWORD environment variable) | `string` | `null` | no |
 | <a name="input_xoa_pool_name"></a> [xoa\_pool\_name](#input\_xoa\_pool\_name) | Default name of the XCP-ng pool as seen in Xen Orchestra | `string` | `null` | no |
-| <a name="input_xoa_username"></a> [xoa\_username](#input\_xoa\_username) | Username for Xen Orchestra API (can be set via XOA\_USERNAME environment variable) | `string` | `null` | no |
 
 ## Outputs
 

--- a/variables.tf
+++ b/variables.tf
@@ -123,11 +123,6 @@ variable "master_tags" {
 }
 
 # Xen Orchestra Settings
-variable "xoa_api_url" {
-  description = "URL for Xen Orchestra API (can be set via XOA_API_URL environment variable)"
-  type        = string
-}
-
 variable "xoa_pool_name" {
   description = "Default name of the XCP-ng pool as seen in Xen Orchestra"
   type        = string
@@ -152,23 +147,6 @@ variable "node_xoa_pool_name" {
   default     = null
 }
 
-variable "xoa_username" {
-  description = "Username for Xen Orchestra API (can be set via XOA_USERNAME environment variable)"
-  type        = string
-  default     = null
-}
-
-variable "xoa_password" {
-  description = "Password for Xen Orchestra API (can be set via XOA_PASSWORD environment variable)"
-  type        = string
-  default     = null
-}
-
-variable "xoa_ignore_ssl" {
-  description = "Ignore SSL verification for Xen Orchestra API (can be set via XOA_IGNORE_SSL environment variable)"
-  type        = bool
-  default     = null
-}
 
 variable "start_delay" {
   description = "The amount of time the cluster virtual machines will wait on XCP-NG host startup"

--- a/xen_data.tf
+++ b/xen_data.tf
@@ -1,15 +1,3 @@
-provider "xenorchestra" {
-  # Configuration options
-  # Must be ws or wss
-  url      = var.xoa_api_url    # Or set XOA_URL environment variable
-  username = var.xoa_username   # Or set XOA_USER environment variable
-  password = var.xoa_password   # Or set XOA_PASSWORD environment variable
-  insecure = var.xoa_ignore_ssl # Or set XOA_INSECURE environment variable to any value
-}
-
-provider "macaddress" {}
-
-
 # docs : https://github.com/terra-farm/terraform-provider-xenorchestra/blob/master/docs/resources/vm.md
 
 locals {


### PR DESCRIPTION
This pull request includes a small change to the `xen_data.tf` file. The change removes the configuration options for the `xenorchestra` provider and the declaration of the `macaddress` provider.

* [`xen_data.tf`](diffhunk://#diff-f171c5fbc9426a5c0ca4b5da79f35c251a43a465bffbc650566b20351d0ba646L1-L12): Removed configuration options for `xenorchestra` provider and declaration of `macaddress` provider.